### PR TITLE
CRM-20189 "hold_date" not updated at multiple bulk email address

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -252,7 +252,7 @@ AND    hold_date IS NULL
           $email->reset_date = 'null';
         }
       }
-      elseif ($email->on_hold == 'null') {
+      elseif ($email->on_hold == 'null' || empty($email->on_hold) {
         $sql = "
 SELECT id
 FROM   civicrm_email


### PR DESCRIPTION
The "hold_date" won't be updated, if the option "Enable multiple bulk email address for a contact" is selected